### PR TITLE
src: Add a method to get power management value.

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -194,6 +194,24 @@ int cyw43_send_ethernet(cyw43_t *self, int itf, size_t len, const void *buf, boo
 int cyw43_wifi_pm(cyw43_t *self, uint32_t pm);
 
 /*!
+ * \brief Get the wifi power management mode
+ *
+ * This method gets the power management mode used by cyw43.
+ * The value is expressed as an unsigned integer 0x00adbrrm where,
+ * m = pm_mode Power management mode
+ * rr = pm2_sleep_ret (in units of 10ms)
+ * b = li_beacon_period
+ * d = li_dtim_period
+ * a = li_assoc
+ * \see cyw43_pm_value for an explanation of these values
+ * This should be called after cyw43_wifi_set_up
+ *
+ * \param pm Power management value
+ * \return 0 on success
+ */
+int cyw43_wifi_get_pm(cyw43_t *self, uint32_t *pm);
+
+/*!
  * \brief Get the wifi link status
  *
  * Returns the status of the wifi link.

--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -485,6 +485,30 @@ int cyw43_wifi_pm(cyw43_t *self, uint32_t pm_in) {
     return ret;
 }
 
+int cyw43_wifi_get_pm(cyw43_t *self, uint32_t *pm_out) {
+    CYW43_THREAD_ENTER;
+    int ret = cyw43_ensure_up(self);
+    if (ret) {
+        CYW43_THREAD_EXIT;
+        return ret;
+    }
+
+    uint32_t pm = 0;
+    uint32_t pm_sleep_ret = 0;
+    uint32_t li_bcn = 0;
+    uint32_t li_dtim = 0;
+    uint32_t li_assoc = 0;
+
+    ret = cyw43_ll_wifi_get_pm(&self->cyw43_ll, &pm, &pm_sleep_ret, &li_bcn, &li_dtim, &li_assoc);
+    if (ret == 0) {
+        // pm_out: 0x00adbrrm
+        *pm_out = cyw43_pm_value((uint8_t)pm, (uint16_t)pm_sleep_ret, (uint8_t)li_bcn, (uint8_t)li_dtim, (uint8_t)li_assoc);
+    }
+    CYW43_THREAD_EXIT;
+
+    return ret;
+}
+
 int cyw43_wifi_get_mac(cyw43_t *self, int itf, uint8_t mac[6]) {
     (void)self;
     (void)itf;

--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -244,6 +244,7 @@ static const uint8_t wifi_nvram_4343[] __attribute__((aligned(4))) =
 #define WLC_GET_ANTDIV (63)
 #define WLC_SET_ANTDIV (64)
 #define WLC_SET_DTIMPRD (78)
+#define WLC_GET_PM (85)
 #define WLC_SET_PM (86)
 #define WLC_SET_GMODE (110)
 #define WLC_SET_WSEC (134)
@@ -781,6 +782,7 @@ static const char *ioctl_cmd_name(int id) {
         CASE_RETURN_STRING(WLC_GET_ANTDIV)
         CASE_RETURN_STRING(WLC_SET_ANTDIV)
         CASE_RETURN_STRING(WLC_SET_DTIMPRD)
+        CASE_RETURN_STRING(WLC_GET_PM)
         CASE_RETURN_STRING(WLC_SET_PM)
         CASE_RETURN_STRING(WLC_SET_GMODE)
         CASE_RETURN_STRING(WLC_SET_WSEC)
@@ -1839,16 +1841,13 @@ static void cyw43_set_ioctl_u32(cyw43_int_t *self, uint32_t cmd, uint32_t val, u
     cyw43_do_ioctl(self, SDPCM_SET, cmd, 4, buf, iface);
 }
 
-#if 0
 static uint32_t cyw43_get_ioctl_u32(cyw43_int_t *self, uint32_t cmd, uint32_t iface) {
     uint8_t *buf = &self->spid_buf[SDPCM_HEADER_LEN + 16];
     cyw43_put_le32(buf, 0);
     cyw43_do_ioctl(self, SDPCM_GET, cmd, 4, buf, iface);
     return cyw43_get_le32(buf);
 }
-#endif
 
-#if 0
 static uint32_t cyw43_read_iovar_u32(cyw43_int_t *self, const char *var, uint32_t iface) {
     uint8_t *buf = &self->spid_buf[SDPCM_HEADER_LEN + 16];
     size_t len = strlen(var) + 1;
@@ -1857,7 +1856,6 @@ static uint32_t cyw43_read_iovar_u32(cyw43_int_t *self, const char *var, uint32_
     cyw43_do_ioctl(self, SDPCM_GET, WLC_GET_VAR, len + 4, buf, iface);
     return cyw43_get_le32(buf);
 }
-#endif
 
 #if 0
 #define WLC_SET_MONITOR (108)
@@ -2012,6 +2010,16 @@ int cyw43_ll_wifi_pm(cyw43_ll_t *self_in, uint32_t pm, uint32_t pm_sleep_ret, ui
     cyw43_put_le32(buf, 0); // any
     cyw43_do_ioctl(self, SDPCM_SET, WLC_SET_BAND, 4, buf, WWD_STA_INTERFACE);
 
+    return 0;
+}
+
+int cyw43_ll_wifi_get_pm(cyw43_ll_t *self_in, uint32_t *pm, uint32_t *pm_sleep_ret, uint32_t *li_bcn, uint32_t *li_dtim, uint32_t *li_assoc) {
+    cyw43_int_t *self = CYW_INT_FROM_LL(self_in);
+    *pm_sleep_ret = cyw43_read_iovar_u32(self, "pm2_sleep_ret", WWD_STA_INTERFACE);
+    *li_bcn = cyw43_read_iovar_u32(self, "bcn_li_bcn", WWD_STA_INTERFACE);
+    *li_dtim = cyw43_read_iovar_u32(self, "bcn_li_dtim", WWD_STA_INTERFACE);
+    *li_assoc = cyw43_read_iovar_u32(self, "assoc_listen", WWD_STA_INTERFACE);
+    *pm = cyw43_get_ioctl_u32(self, WLC_GET_PM, WWD_STA_INTERFACE);
     return 0;
 }
 

--- a/src/cyw43_ll.h
+++ b/src/cyw43_ll.h
@@ -258,6 +258,7 @@ int cyw43_ll_send_ethernet(cyw43_ll_t *self, int itf, size_t len, const void *bu
 
 int cyw43_ll_wifi_on(cyw43_ll_t *self, uint32_t country);
 int cyw43_ll_wifi_pm(cyw43_ll_t *self, uint32_t pm, uint32_t pm_sleep_ret, uint32_t li_bcn, uint32_t li_dtim, uint32_t li_assoc);
+int cyw43_ll_wifi_get_pm(cyw43_ll_t *self, uint32_t *pm, uint32_t *pm_sleep_ret, uint32_t *li_bcn, uint32_t *li_dtim, uint32_t *li_assoc);
 int cyw43_ll_wifi_scan(cyw43_ll_t *self, cyw43_wifi_scan_options_t *opts);
 
 int cyw43_ll_wifi_join(cyw43_ll_t *self, size_t ssid_len, const uint8_t *ssid, size_t key_len, const uint8_t *key, uint32_t auth_type, const uint8_t *bssid, uint32_t channel);


### PR DESCRIPTION
Re-enable cyw43_read_iovar_u32 and add cyw43_get_ioctl_u32
Rename cyw43_do_ioctl_u32 to cyw43_set_ioctl_u32 as it better describes
what it's used for.

Fixes #5

Signed-off-by: Peter Harper <peter.harper@raspberrypi.com>