### PR TITLE
Implement a multicast filtering api and enable v6 for lwip

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -115,7 +115,9 @@ typedef struct _cyw43_t {
     #if CYW43_LWIP
     // lwIP data
     struct netif netif[2];
+    #if LWIP_IPV4
     struct dhcp dhcp_client;
+    #endif
     #endif
 
     #if CYW43_NETUTILS

--- a/src/cyw43_lwip.c
+++ b/src/cyw43_lwip.c
@@ -102,6 +102,7 @@ STATIC err_t cyw43_netif_output(struct netif *netif, struct pbuf *p) {
     return ERR_OK;
 }
 
+#if LWIP_IGMP
 STATIC err_t cyw43_netif_update_igmp_mac_filter(struct netif *netif, const ip4_addr_t *group, enum netif_mac_filter_action action) {
     cyw43_t *self = netif->state;
     uint8_t mac[] = { 0x01, 0x00, 0x5e, ip4_addr2(group) & 0x7F, ip4_addr3(group), ip4_addr4(group) };
@@ -116,6 +117,7 @@ STATIC err_t cyw43_netif_update_igmp_mac_filter(struct netif *netif, const ip4_a
 
     return ERR_OK;
 }
+#endif
 
 #if LWIP_IPV6
 STATIC err_t cyw43_macfilter(struct netif *netif, const ip6_addr_t *group, enum netif_mac_filter_action action) {
@@ -143,7 +145,9 @@ STATIC err_t cyw43_netif_init(struct netif *netif) {
     #endif
     cyw43_wifi_get_mac(netif->state, netif->name[1] - '0', netif->hwaddr);
     netif->hwaddr_len = sizeof(netif->hwaddr);
+    #if LWIP_IGMP
     netif_set_igmp_mac_filter(netif, cyw43_netif_update_igmp_mac_filter);
+    #endif
     return ERR_OK;
 }
 


### PR DESCRIPTION
This is related to #19 should resolve #18.
Thanks to the good hint in from @peterharperuk  https://github.com/georgerobotics/cyw43-driver/issues/18#issuecomment-1225913653 I was able to use the mac address filtering. With these changes applied, ipv6 works perfectly for me.
And hints? Should I split up the 2 commits into to separate PRs?