### PR TITLE
src: Implement LWIP's IGMP MAC filter callback.

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -263,6 +263,19 @@ void cyw43_wifi_set_up(cyw43_t *self, int itf, bool up, uint32_t country);
 int cyw43_wifi_get_mac(cyw43_t *self, int itf, uint8_t mac[6]);
 
 /*!
+ * \brief Add/remove multicast group address
+ *
+ * This method adds/removes an address from the multicast filter, allowing
+ * frames sent to this group to be received
+ *
+ * \param self the driver state object. This should always be \c &cyw43_state
+ * \param addr a buffer containing a group mac address
+ * \param add true to add the address, false to remove it
+ * \return 0 on success
+ */
+int cyw43_wifi_update_multicast_filter(cyw43_t *self, uint8_t *addr, bool add);
+
+/*!
  * \brief Perform a wifi scan for wifi networks
  *
  * Start a scan for wifi networks. Results are returned via the callback.

--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -516,6 +516,13 @@ int cyw43_wifi_get_mac(cyw43_t *self, int itf, uint8_t mac[6]) {
     return 0;
 }
 
+int cyw43_wifi_update_multicast_filter(cyw43_t *self, uint8_t *addr, bool add) {
+    CYW43_THREAD_ENTER;
+    int ret = cyw43_ll_wifi_update_multicast_filter(&self->cyw43_ll, addr, add);
+    CYW43_THREAD_EXIT;
+    return ret;
+}
+
 void cyw43_wifi_set_up(cyw43_t *self, int itf, bool up, uint32_t country) {
     CYW43_THREAD_ENTER;
     if (up) {

--- a/src/cyw43_ll.h
+++ b/src/cyw43_ll.h
@@ -277,6 +277,9 @@ int cyw43_ll_gpio_get(cyw43_ll_t *self_in, int gpio_n, bool *gpio_en);
 // Get mac address
 int cyw43_ll_wifi_get_mac(cyw43_ll_t *self_in, uint8_t *addr);
 
+// Add/remove multicast address
+int cyw43_ll_wifi_update_multicast_filter(cyw43_ll_t *self_in, uint8_t *addr, bool add);
+
 // Returns true while there's work to do
 bool cyw43_ll_has_work(cyw43_ll_t *self);
 

--- a/src/cyw43_lwip.c
+++ b/src/cyw43_lwip.c
@@ -39,6 +39,7 @@
 #if CYW43_LWIP
 #include "lwip/etharp.h"
 #include "lwip/dns.h"
+#include "lwip/igmp.h"
 #include "lwip/apps/mdns.h"
 #include "lwip/tcpip.h"
 #include "netif/ethernet.h"
@@ -101,6 +102,21 @@ STATIC err_t cyw43_netif_output(struct netif *netif, struct pbuf *p) {
     return ERR_OK;
 }
 
+STATIC err_t cyw32_netif_update_igmp_mac_filter(struct netif *netif, const ip4_addr_t *group, enum netif_mac_filter_action action) {
+    cyw43_t *self = netif->state;
+    uint8_t mac[] = { 0x01, 0x00, 0x5e, ip4_addr2(group) & 0x7F, ip4_addr3(group), ip4_addr4(group) };
+
+    if (action != IGMP_ADD_MAC_FILTER && action != IGMP_DEL_MAC_FILTER) {
+        return ERR_VAL;
+    }
+
+    if (cyw43_wifi_update_multicast_filter(self, mac, action == IGMP_ADD_MAC_FILTER)) {
+        return ERR_IF;
+    }
+
+    return ERR_OK;
+}
+
 STATIC err_t cyw43_netif_init(struct netif *netif) {
     netif->linkoutput = cyw43_netif_output;
     netif->output = etharp_output;
@@ -108,6 +124,7 @@ STATIC err_t cyw43_netif_init(struct netif *netif) {
     netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_ETHERNET | NETIF_FLAG_IGMP;
     cyw43_wifi_get_mac(netif->state, netif->name[1] - '0', netif->hwaddr);
     netif->hwaddr_len = sizeof(netif->hwaddr);
+    netif_set_igmp_mac_filter(netif, cyw32_netif_update_igmp_mac_filter);
     return ERR_OK;
 }
 


### PR DESCRIPTION
This is used to register the multicast group address on the wifi
interface's filter, allowing frames to that group to be received.

This only applies to v4. See #24 for the equivalent v6 change.

Fixes https://github.com/micropython/micropython/issues/9105