### PR TITLE
src: mDns fixes.

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -116,6 +116,7 @@ typedef struct _cyw43_t {
     // lwIP data
     struct netif netif[2];
     struct dhcp dhcp_client;
+    bool mdns_init;
     #endif
 
     #if CYW43_NETUTILS

--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -47,6 +47,10 @@
 #define USE_SDIOIT (1)
 #endif
 
+#if CYW43_LWIP
+#include "lwip/apps/mdns.h"
+#endif
+
 // Bits 0-3 are an enumeration, while bits 8-11 are flags.
 #define WIFI_JOIN_STATE_KIND_MASK (0x000f)
 #define WIFI_JOIN_STATE_ACTIVE  (0x0001)
@@ -408,6 +412,10 @@ void cyw43_cb_process_async_event(void *cb_data, const cyw43_async_event_t *ev) 
         // STA connected
         self->wifi_join_state = WIFI_JOIN_STATE_ACTIVE;
         cyw43_cb_tcpip_set_link_up(self, CYW43_ITF_STA);
+
+        #if LWIP_MDNS_RESPONDER
+        mdns_resp_announce(&self->netif[CYW43_ITF_STA]);
+        #endif
     }
 }
 


### PR DESCRIPTION
The host name for mDns wasn't using CYW43_HOST_NAME. The mdns_resp_add_netif changed after lwip version 2.1.2. Avoid calling mdns_resp_remove_netif if it's not been added. Call mdns_resp_announce when STA connected.

Fixes #16 and #17