### PR TITLE
Add support for setting hostname

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -105,6 +105,8 @@
 #define CYW43_LINK_BADAUTH      (-3)    ///< Authenticatation failure
 //!\}
 
+#define CYW43_MAX_LEN_HOSTNAME  (16)
+
 typedef struct _cyw43_t {
     cyw43_ll_t cyw43_ll;
 
@@ -149,6 +151,7 @@ typedef struct _cyw43_t {
     #if CYW43_ENABLE_BLUETOOTH
     bool bt_loaded;
     #endif
+    char hostname[CYW43_MAX_LEN_HOSTNAME];
 } cyw43_t;
 
 extern cyw43_t cyw43_state;

--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -105,6 +105,12 @@
 #define CYW43_LINK_BADAUTH      (-3)    ///< Authenticatation failure
 //!\}
 
+// default hostname. can be overriden by setting the hostname field of the cyw43_t struct
+// *after* cyw43_init has been called
+#ifndef CYW43_HOST_NAME
+#define CYW43_HOST_NAME "PYBD"
+#endif
+
 #define CYW43_MAX_LEN_HOSTNAME  (16)
 
 typedef struct _cyw43_t {

--- a/src/cyw43_config.h
+++ b/src/cyw43_config.h
@@ -69,7 +69,7 @@
 
 // This include should define a wifi_nvram_4343[] variable.
 #ifndef CYW43_WIFI_NVRAM_INCLUDE_FILE
-#define CYW43_WIFI_NVRAM_INCLUDE_FILE "firmware/wifi_nvram_43439.h"
+#define CYW43_WIFI_NVRAM_INCLUDE_FILE "../firmware/wifi_nvram_43439.h"
 #endif
 
 // This should be defined by the port if needed, to override the default

--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -110,6 +110,7 @@ void cyw43_init(cyw43_t *self) {
     self->ap_channel = 3;
     self->ap_ssid_len = 0;
     self->ap_key_len = 0;
+    strncpy(self->hostname, CYW43_HOST_NAME, CYW43_MAX_LEN_HOSTNAME);
 
     cyw43_poll = NULL;
     self->initted = true;

--- a/src/cyw43_lwip.c
+++ b/src/cyw43_lwip.c
@@ -161,10 +161,6 @@ STATIC err_t cyw43_netif_init(struct netif *netif) {
 //}
 //#endif
 
-#ifndef CYW43_HOST_NAME
-#define CYW43_HOST_NAME "PYBD"
-#endif
-
 void cyw43_cb_tcpip_init(cyw43_t *self, int itf) {
     ip_addr_t ipconfig[4];
     #if LWIP_IPV6
@@ -206,8 +202,6 @@ void cyw43_cb_tcpip_init(cyw43_t *self, int itf) {
     #else
     #error Unsupported
     #endif
-    // locally hack pico id into hostname
-    // this creates an unwanted dep on pico-sdk
     netif_set_hostname(n, self->hostname);
     netif_set_default(n);
     netif_set_up(n);

--- a/src/cyw43_lwip.c
+++ b/src/cyw43_lwip.c
@@ -232,15 +232,6 @@ void cyw43_cb_tcpip_init(cyw43_t *self, int itf) {
         dhcp_server_init(&self->dhcp_server, &ipconfig[0], &ipconfig[1]);
         #endif
     }
-
-    #if LWIP_MDNS_RESPONDER
-    // TODO better to call after IP address is set
-    char mdns_hostname[9];
-    strncpy(&mdns_hostname[0], self->hostname, 9);
-    cyw43_hal_get_mac_ascii(CYW43_HAL_MAC_WLAN0, 8, 4, &mdns_hostname[4]);
-    mdns_hostname[8] = '\0';
-    mdns_resp_add_netif(n, mdns_hostname, 60);
-    #endif
 }
 
 void cyw43_cb_tcpip_deinit(cyw43_t *self, int itf) {

--- a/src/cyw43_lwip.c
+++ b/src/cyw43_lwip.c
@@ -42,6 +42,7 @@
 #include "lwip/igmp.h"
 #include "lwip/tcpip.h"
 #include "netif/ethernet.h"
+#include "pico/unique_id.h"
 #endif
 
 #if CYW43_NETUTILS
@@ -206,7 +207,13 @@ void cyw43_cb_tcpip_init(cyw43_t *self, int itf) {
     #else
     #error Unsupported
     #endif
-    netif_set_hostname(n, CYW43_HOST_NAME);
+    // locally hack pico id into hostname
+    // this creates an unwanted dep on pico-sdk
+    pico_unique_board_id_t id;
+    pico_get_unique_board_id(&id);
+    static char hostname[16] = {0};
+    sprintf(hostname, "picow-%02x%02x%02x%02x", id.id[4], id.id[5], id.id[6], id.id[7]);
+    netif_set_hostname(n, hostname);
     netif_set_default(n);
     netif_set_up(n);
 


### PR DESCRIPTION
Use case is having multiple rp2 (pico w) on network. Previously the hostname was hard-coded to "PYBD" (which is still the default), now the client can optionally set the hostname *after* calling init, e.g.:

```c
cyw43_init(&cyw43_state);
// set hostname
snprintf(cyw43_state.hostname, CYW43_MAX_LEN_HOSTNAME, "picow-1234");
```