### PR TITLE
cyw43_ll.c: Increase the default EAPOL key messages timeout.

### DIFF
--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -265,6 +265,8 @@ static void cyw43_xxd(size_t len, const uint8_t *buf) {
 #define CYW_INT_FROM_LL(ll) ((cyw43_int_t *)(ll))
 #define CYW_INT_TO_LL(in) ((cyw43_ll_t *)(in))
 
+#define CYW_EAPOL_KEY_TIMEOUT (5000)
+
 static int cyw43_ll_sdpcm_poll_device(cyw43_int_t *self, size_t *len, uint8_t **buf);
 static void cyw43_write_iovar_n(cyw43_int_t *self, const char *var, size_t len, const void *buf, uint32_t iface);
 
@@ -2073,8 +2075,8 @@ int cyw43_ll_wifi_join(cyw43_ll_t *self_in, size_t ssid_len, const uint8_t *ssid
     cyw43_write_iovar_u32_u32(self, "bsscfg:sup_wpa2_eapver", 0, -1, WWD_STA_INTERFACE);
 
     // wwd_wifi_set_supplicant_eapol_key_timeout
-    CYW43_VDEBUG("Setting sup_wpa_tmo %d\n", 0x9c4);
-    cyw43_write_iovar_u32_u32(self, "bsscfg:sup_wpa_tmo", 0, 0x9c4, WWD_STA_INTERFACE);
+    CYW43_VDEBUG("Setting sup_wpa_tmo %d\n", CYW_EAPOL_KEY_TIMEOUT);
+    cyw43_write_iovar_u32_u32(self, "bsscfg:sup_wpa_tmo", 0, CYW_EAPOL_KEY_TIMEOUT, WWD_STA_INTERFACE);
 
     if (auth_type != 0) {
         // wwd_wifi_set_passphrase


### PR DESCRIPTION
I've been debugging this issue for a while and I can reproduce it with 2 different access points, and with both the PYBD_SF2 and Portenta-H7 (with the closed source driver). On both boards, if the EAPOL key exchange times out (which happens very frequently with the APs I'm testing with) the boards will rejoin (using the same timeout) and just get stuck in a rejoin/timeout loop. See the following trace, which repeats forever:
```
[  293728] ASYNC(0000,ASSOC_REQ_IE,0,0,0)
[  293729] ASYNC(0000,AUTH,0,0,0)
[  293735] ASYNC(0000,ASSOC_RESP_IE,0,0,0)
[  293735] ASYNC(0000,ASSOC,0,0,0)
[  293735] ASYNC(0001,LINK,0,0,0)
[  293762] ASYNC(0000,JOIN,0,0,0)
[  293762] ASYNC(0000,SET_SSID,0,0,0)
[  294736] ASYNC(0000,PSK_SUP,4,15,0)
Supplicant M1 timeout event
[  295045] ASYNC(0000,ASSOC_REQ_IE,0,0,0)
[  295045] ASYNC(0000,AUTH,0,0,0)
[  295051] ASYNC(0000,ASSOC_RESP_IE,0,0,0)
[  295051] ASYNC(0000,ASSOC,0,0,0)
[  295051] ASYNC(0001,LINK,0,0,0)
[  295093] ASYNC(0000,JOIN,0,0,0)
[  295093] ASYNC(0000,SET_SSID,0,0,0)
[  296014] ASYNC(0000,51,0,0,0)
[  296052] ASYNC(0000,PSK_SUP,4,15,0)
Supplicant M1 timeout event
[  296219] ASYNC(0000,51,0,0,0)
[  296366] ASYNC(0000,ASSOC_REQ_IE,0,0,0)
[  296367] ASYNC(0000,AUTH,0,0,0)
[  296373] ASYNC(0000,ASSOC_RESP_IE,0,0,0)
[  296373] ASYNC(0000,ASSOC,0,0,0)
[  296373] ASYNC(0001,LINK,0,0,0)
[  296425] ASYNC(0000,JOIN,0,0,0)
[  296425] ASYNC(0000,SET_SSID,0,0,0)
[  297373] ASYNC(0000,PSK_SUP,4,15,0)
Supplicant M1 timeout event
[  297686] ASYNC(0000,ASSOC_REQ_IE,0,0,0)
```

This can be reproduced if the timeout is set too low (for example, for the APs I'm using 1000ms is always triggers this issue).

* Note I have an alternate fix for this issue, which I also tested, but it requires more changes. A function to set `sup_wpa_tmo` can be exported, and in `cyw43_ctrl.c` on M1/M3/G1 timeout, the `sup_wpa_tmo` can be set to a bigger value. However, this is PR is a much simpler fix and 5000ms is not unreasonable.