### PR TITLE
src: Remove mDNS from cyw43-driver.

### DIFF
--- a/src/cyw43_lwip.c
+++ b/src/cyw43_lwip.c
@@ -39,7 +39,6 @@
 #if CYW43_LWIP
 #include "lwip/etharp.h"
 #include "lwip/dns.h"
-#include "lwip/apps/mdns.h"
 #include "lwip/tcpip.h"
 #include "netif/ethernet.h"
 #endif
@@ -172,15 +171,6 @@ void cyw43_cb_tcpip_init(cyw43_t *self, int itf) {
         dhcp_server_init(&self->dhcp_server, &ipconfig[0], &ipconfig[1]);
         #endif
     }
-
-    #if LWIP_MDNS_RESPONDER
-    // TODO better to call after IP address is set
-    char mdns_hostname[9];
-    memcpy(&mdns_hostname[0], CYW43_HOST_NAME, 4);
-    cyw43_hal_get_mac_ascii(CYW43_HAL_MAC_WLAN0, 8, 4, &mdns_hostname[4]);
-    mdns_hostname[8] = '\0';
-    mdns_resp_add_netif(n, mdns_hostname, 60);
-    #endif
 }
 
 void cyw43_cb_tcpip_deinit(cyw43_t *self, int itf) {
@@ -192,9 +182,6 @@ void cyw43_cb_tcpip_deinit(cyw43_t *self, int itf) {
         dhcp_server_deinit(&self->dhcp_server);
         #endif
     }
-    #if LWIP_MDNS_RESPONDER
-    mdns_resp_remove_netif(n);
-    #endif
     for (struct netif *netif = netif_list; netif != NULL; netif = netif->next) {
         if (netif == n) {
             netif_remove(netif);


### PR DESCRIPTION
The lwip mDNS API has changed which can cause problems building it. The suggestion is that this code should not be in the driver anyway, so remove it.

Fixes #17