### PR TITLE
Add handling for open networks to cyw43_ll_wifi_join.

### DIFF
--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -2055,7 +2055,9 @@ int cyw43_ll_wifi_join(cyw43_ll_t *self_in, size_t ssid_len, const uint8_t *ssid
     }
 
     uint32_t wpa_auth = 0;
-    if (auth_type == CYW43_AUTH_WPA2_AES_PSK || auth_type == CYW43_AUTH_WPA2_MIXED_PSK) {
+    if (auth_type == CYW43_AUTH_OPEN) {
+        wpa_auth = 0;
+    } else if (auth_type == CYW43_AUTH_WPA2_AES_PSK || auth_type == CYW43_AUTH_WPA2_MIXED_PSK) {
         wpa_auth = CYW43_WPA2_AUTH_PSK;
     } else if (auth_type == CYW43_AUTH_WPA_TKIP_PSK) {
         wpa_auth = CYW43_WPA_AUTH_PSK;


### PR DESCRIPTION
Fix for #27 
- Add handling for auth_type == 0 to IF.
- The IF on line 2038 provided handling for networks without security (open networks). However, this handling is never used due to it being ignored by the IF on line 2013.
- Reproducibly fixes open network connection issues observed by Raspberry Pi Pico W MicroPython users (discussed [here](https://github.com/micropython/micropython/issues/9016#issuecomment-1219896195)) using `security=0` parameter.