### PR TITLE
Make cyw43_async_event_name_table const so it goes to flash

### DIFF
--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -272,7 +272,7 @@ void cyw43_cb_ensure_awake(void *cb_data) {
     #endif
 }
 
-STATIC const char *cyw43_async_event_name_table[89] = {
+STATIC const char *const cyw43_async_event_name_table[89] = {
     //[0 ... 88] = NULL,
     [CYW43_EV_SET_SSID] = "SET_SSID",
     [CYW43_EV_JOIN] = "JOIN",


### PR DESCRIPTION
Checking the map file, `cyw43_async_event_name_table` was in RAM instead of flash, despite being "read only".
Needs an additional const.