### PR TITLE
src: Channel fix in cyw43_ll_wifi_join.

### DIFF
--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -2129,9 +2129,11 @@ int cyw43_ll_wifi_join(cyw43_ll_t *self_in, size_t ssid_len, const uint8_t *ssid
         #define WL_CHANSPEC_CTL_SB_NONE     WL_CHANSPEC_CTL_SB_LLL
         #define WL_CHANSPEC_BAND_2G        0x0000
         memcpy(buf + 4 + 32 + 20, bssid, 6);
-        cyw43_put_le32(buf + 4 + 32 + 20 + 8, 1); // chanspec_num
-        uint16_t chspec = channel | WL_CHANSPEC_BW_20 | WL_CHANSPEC_CTL_SB_NONE | WL_CHANSPEC_BAND_2G;
-        cyw43_put_le16(buf + 4 + 32 + 20 + 12, chspec); // chanspec_list
+        if (channel != CYW43_CHANNEL_NONE) {
+            cyw43_put_le32(buf + 4 + 32 + 20 + 8, 1); // chanspec_num
+            uint16_t chspec = channel | WL_CHANSPEC_BW_20 | WL_CHANSPEC_CTL_SB_NONE | WL_CHANSPEC_BAND_2G;
+            cyw43_put_le16(buf + 4 + 32 + 20 + 12, chspec); // chanspec_list
+        }
 
         // join the AP
         CYW43_VDEBUG("Join AP\n");

--- a/src/cyw43_ll.h
+++ b/src/cyw43_ll.h
@@ -181,6 +181,11 @@
 #define CYW43_PM2_POWERSAVE_MODE          (2) ///< Powersave mode on specified interface with High throughput
 
 /*!
+ * \brief To indicate no specific channel when calling cyw43_ll_wifi_join with bssid specified
+ */
+#define CYW43_CHANNEL_NONE (0xffffffff) ///< No Channel specified (use the AP's channel)
+
+/*!
  * \brief Network interface types
  * \anchor CYW43_ITF_
  */


### PR DESCRIPTION
Joining to wifi via BSSID doesn't appear to work.
Don't set the channel count if the channel is not set.

Fixes #54