### PR TITLE
cyw43_ll: Support using this driver on stm32 (pybd, portenta).

### DIFF
--- a/src/cyw43_config.h
+++ b/src/cyw43_config.h
@@ -44,6 +44,10 @@
 #define CYW43_USE_SPI (0)
 #endif
 
+#ifndef CYW43_CLEAR_SDIO_INT
+#define CYW43_CLEAR_SDIO_INT (0)
+#endif
+
 // Firmware configuration.
 
 // This include should define a wifi_nvram_4343[] variable.

--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -2061,7 +2061,7 @@ int cyw43_ll_wifi_join(cyw43_ll_t *self_in, size_t ssid_len, const uint8_t *ssid
         wpa_auth = CYW43_WPA_AUTH_PSK;
     } else {
         // Unsupported auth_type (security) value.
-        return -1;
+        return -CYW43_EINVAL;
     }
 
     CYW43_VDEBUG("Setting wsec=0x%lx\n", auth_type & 0xff);


### PR DESCRIPTION
Minor changes to make this version of the driver behave identically to the version that was previously used in MicroPython for stm32 boards such as GR pybd and Arduino Portenta.

The driver worked as-is, but with two performance regressions fixed by this PR.
- The SDIO interrupt was not being handled correctly.
- The 1DX module (used on both boards) used needs to set revision 17 when using the "worldwide" region.

Also makes it return `EINVAL` rather than `-1` (i.e. `EPERM`) when setting an invalid auth type for connection.

_This work was funded through GitHub Sponsors._