### PR TITLE
Add option to allow disabling LWIP

### DIFF
--- a/src/cyw43_config.h
+++ b/src/cyw43_config.h
@@ -91,8 +91,10 @@
 // Miscellaneous configuration.
 
 // No other options right now for TCP/IP stack.
+#ifndef CYW43_LWIP_DISABLE
 #ifndef CYW43_LWIP
 #define CYW43_LWIP (1)
+#endif
 #endif
 
 #ifndef CYW43_NETUTILS


### PR DESCRIPTION
I ported NetX running on Pico W and need to disable LWIP. Projects here: https://github.com/TiejunMS/Azure-RTOS-on-Raspberry-Pi-Pico-RP2040/tree/main/demo_netx