### PR TITLE
Add dependency generation to Makefile

### DIFF
--- a/tests/sdio/Makefile
+++ b/tests/sdio/Makefile
@@ -47,3 +47,11 @@ OBJ_DIRS = $(sort $(dir $(OBJ)))
 $(OBJ): | $(OBJ_DIRS)
 $(OBJ_DIRS):
 	$(MKDIR) -p $@
+
+# Dependency generation
+%.o: %.d
+CFLAGS += -MP -MMD
+DEP := $(OBJ:.o=.d)
+$(DEP):
+
+-include $(DEP)


### PR DESCRIPTION
Dependency generation makes sure targets are determined out of date should any included headers be out of date.

Tested by rebuilding across changes to cyw43_configport.h.