### PR TITLE
Add include-what-you-use test for public headers

### DIFF
--- a/src/cyw43_internal.h
+++ b/src/cyw43_internal.h
@@ -34,6 +34,12 @@
 #ifndef CYW43_INCLUDED_CYW43_INTERNAL_H
 #define CYW43_INCLUDED_CYW43_INTERNAL_H
 
+#include "cyw43_ll.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
 #define BUS_FUNCTION (0)
 #define BACKPLANE_FUNCTION (1)
 #define WLAN_FUNCTION (2)

--- a/src/cyw43_sdio.h
+++ b/src/cyw43_sdio.h
@@ -34,6 +34,10 @@
 #ifndef CYW43_INCLUDED_CYW43_SDIO_H
 #define CYW43_INCLUDED_CYW43_SDIO_H
 
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
 // These must be provided by a port, if the SDIO bus interface is used.
 void cyw43_sdio_init(void);
 void cyw43_sdio_reinit(void);

--- a/src/cyw43_spi.h
+++ b/src/cyw43_spi.h
@@ -34,6 +34,11 @@
 #ifndef CYW43_INCLUDED_CYW43_SPI_H
 #define CYW43_INCLUDED_CYW43_SPI_H
 
+#include "cyw43_internal.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
 // Test register value
 #define TEST_PATTERN 0xFEEDBEADu
 

--- a/tests/sdio/Makefile
+++ b/tests/sdio/Makefile
@@ -48,10 +48,32 @@ $(OBJ): | $(OBJ_DIRS)
 $(OBJ_DIRS):
 	$(MKDIR) -p $@
 
+# "Include-what-you-use"-test compilation for public headers
+PUBLIC_HEADER := \
+	src/cyw43.h \
+	src/cyw43_btbus.h \
+	src/cyw43_country.h \
+	src/cyw43_sdio.h \
+	src/cyw43_spi.h \
+	src/cyw43_stats.h \
+
+vpath %.h . $(CYW43_TOP)
+
+PUBLIC_HEADER_GCH := $(patsubst %,$(BUILD)/%.gch,$(PUBLIC_HEADER))
+
+# Static pattern rule testing header compilation by making a pre-compiled header of each
+$(PUBLIC_HEADER_GCH): $(BUILD)/%.h.gch: %.h
+# Pass -Wno-pedantic to suppress "empty translation unit" errors
+	$(CC) $(CFLAGS) -Wno-pedantic -c $< -o $@
+
+# Add to phony test target trigger
+test: $(PUBLIC_HEADER_GCH)
+
 # Dependency generation
 %.o: %.d
+%.gch: %.d
 CFLAGS += -MP -MMD
-DEP := $(OBJ:.o=.d)
+DEP := $(OBJ:.o=.d) $(PUBLIC_HEADER_GCH:.gch=.d)
 $(DEP):
 
 -include $(DEP)


### PR DESCRIPTION
For each public header a test is added to see whether it can be compiled into a pre-compiled header. Success indicates the header includes all the necessary headers.

Headers missing includes have been fixed.

Testing added to phony "test" target.

Dependency generation included.