### PR TITLE
cyw43_ll.c: Fix NVRAM data load address.

### DIFF
--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -1672,7 +1672,7 @@ alp_set:
     cyw43_download_resource(self, 0x00000000, CYW43_WIFI_FW_LEN, 1, 0x100 + 0x1000);
     */
 
-    size_t wifi_nvram_len = ALIGN_UINT(sizeof(wifi_nvram_4343), 64);
+    size_t wifi_nvram_len = ALIGN_UINT(sizeof(wifi_nvram_4343), 256);
     const uint8_t *wifi_nvram_data = wifi_nvram_4343;
     cyw43_download_resource(self, CYW43_RAM_SIZE - 4 - wifi_nvram_len, wifi_nvram_len, 0, (uintptr_t)wifi_nvram_data);
     uint32_t sz = ((~(wifi_nvram_len / 4) & 0xffff) << 16) | (wifi_nvram_len / 4);


### PR DESCRIPTION
The address to which the NVRAM data is loaded, is calculated before rounding up the NVRAM data size (again) in `cyw43_download_resource()`, which causes the destination address (addr + offset) to overflow the end of the RAM. By rounding up the NVRAM data size to the same size used in `cyw43_download_resource()` (256), the correct offset is calculated.

If you enable the assertions somehow on `stm32`, enable all the debugging output macros, and enable `VERIFY_FIRMWARE_DOWNLOAD` you can see that it fails to verify the NVRAM data:

```bash
backplane is up
backplane is ready
ALP is set
writing resource 383232 bytes to 0x0
Version: 7.45.98.50 (r688715 CY) CRC: c93a9c0a Date: Mon 2018-04-30 04:15:59 PDT Ucode Ver: 1043.2107 FWID 01-283fcdb9
done dnload; dt = 46875 us; speed = 8175 kbytes/sec
done verify; dt = 45810 us; speed = 8365 kbytes/sec
writing resource 768 bytes to 0x7fd7c
Assertion failed address: 0x807c
done dnload; dt = 3067 us; speed = 250 kbytes/sec
Assertion failed address: 0x807c
sdio_transfer_cmd53: error=00000002 wr=0 len=256 dma=1 buf_idx=0 STA=00000000 SDMMC=00000080:00000c62 IDMA=00000001
[CYW43] fail verify at address 0x0007ff7c:
 64 64 72 3d 30 30 3a 39 30 3a 34 63 3a 63 35 3a 31 32 3a 33 38 00 77 6c 30 69 64 3d 30 78 34 33 31 62 00 6d 75 78 65 6e 61 62 3d 30 78 31 30 00 73 77 64 69 76 5f 65 6e 3d 31 00 73 77 64 69 76 5f 67 70 69 6f 3d 31 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 02 00 00 00 04 00 00 00 08 00 00 00 10 00 00 00 20 00 00 00 40 00 00 00 80 00 00 00 1b 00 00 00 36 63 7c 77 7b f2 6b 6f c5 30 01 67 2b fe d7 ab 76 ca 82 c9 7d fa 59 47 f0 ad d4 a2 af 9c a4 72 c0 b7 fd 93 26 36 3f f7 cc 34 a5 e5 f1 71 d8 31 15 04 c7 23 c3 18 96 05 9a 07 12 80 e2 eb 27 b2 75 09 83 2c 1a 1b 6e 5a a0 52 3b d6 b3 29 e3 2f 84 53 d1 00 ed 20 fc b1 5b 6a cb be 39 4a 4c 58 cf d0 ef aa fb 43 4d 33 85 45 f9 02 7f 50 3c 9f a8 51 a3 40 8f 92 9d 38 f5 bc b6 da 21 10 ff f3 d2 cd 0c 13 ec 5f 97 44 17
 64 64 72 3d 30 30 3a 39 30 3a 34 63 3a 63 35 3a 31 32 3a 33 38 00 77 6c 30 69 64 3d 30 78 34 33 31 62 00 6d 75 78 65 6e 61 62 3d 30 78 31 30 00 73 77 64 69 76 5f 65 6e 3d 31 00 73 77 64 69 76 5f 67 70 69 6f 3d 31 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 02 00 00 00 04 00 00 00 08 00 00 00 10 00 00 00 20 00 00 00 40 00 00 00 80 00 00 00 1b 00 00 00 36 63 7c 77 7b f2 6b 6f c5 6d 72 65 76 3d 31 31 00 62 6f 61 72 64 66 6c 61 67 73 3d 30 78 30 30 34 30 34 32 30 31 00 62 6f 61 72 64 66 6c 61 67 73 33 3d 30 78 30 38 30 30 30 30 30 30 00 78 74 61 6c 66 72 65 71 3d 33 37 34 30 30 00 6e 6f 63 72 63 3d 31 00 61 67 30 3d 30 00 61 61 32 67 3d 31 00 63 63 6f 64 65 3d 41 4c 4c 00 65 78 74 70 61 67 61 69 6e 32 67 3d 30 00 70 61 32 67 61 30 3d 2d 31 34 35 2c 36 36 36
core 1 IS up
wake bus
```