### PR TITLE
cyw43_ctrl.c: Use port-defined extint_set and GPIO IT constants.

### DIFF
--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -205,8 +205,7 @@ STATIC int cyw43_ensure_up(cyw43_t *self) {
     #if USE_SDIOIT
     cyw43_sdio_set_irq(true);
     #elif !CYW43_USE_SPI
-    extern void extint_set(const pin_obj_t *pin, uint32_t mode);
-    extint_set(CYW43_PIN_WL_HOST_WAKE, GPIO_MODE_IT_FALLING);
+    cyw43_hal_pin_extint(CYW43_PIN_WL_HOST_WAKE, CYW43_HAL_PIN_MODE_IT_FALLING);
     #endif
 
     // Kick things off


### PR DESCRIPTION
The `extint_set` function and `GPIO_IT_` constants are only defined for the `stm32` port. To improve the portability of the host-wake/OOB mode, those names are replaced with `CYW43_` constants to be defined in ports `cyw43_configport.h`files, when they're used.

NOTE this is a breaking change which will require updating at least the `stm32/cyw43_configport.h` file.