### PR TITLE
Fix get_stas() bug

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -474,6 +474,7 @@ static inline void cyw43_wifi_ap_set_auth(cyw43_t *self, uint32_t auth) {
  *
  * \param self the driver state object. This should always be \c &cyw43_state
  * \param max_stas Returns the maximum number of devices (STAs) that can be connected to the access point
+ * (set to 0 on error)
  */
 void cyw43_wifi_ap_get_max_stas(cyw43_t *self, int *max_stas);
 
@@ -484,9 +485,10 @@ void cyw43_wifi_ap_get_max_stas(cyw43_t *self, int *max_stas);
  * connected to the wifi access point.
  *
  * \param self the driver state object. This should always be \c &cyw43_state
- * \param num_stas Returns the number of devices (STA) connected to the access point
- * \param macs Returns the mac addresses of devies (STA) connected to the access point.
- * The supplied buffer should have enough room for 6 bytes per mac address.
+ * \param num_stas Caller must provide the number of MACs that will fit in the macs buffer;
+ * The supplied buffer should have enough room for 6 bytes per MAC address.
+ * Returns the number of devices (STA) connected to the access point.
+ * \param macs Returns up to num_stas MAC addresses of devices (STA) connected to the access point.
  * Call \ref cyw43_wifi_ap_get_max_stas to determine how many mac addresses can be returned.
  */
 void cyw43_wifi_ap_get_stas(cyw43_t *self, int *num_stas, uint8_t *macs);

--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -707,7 +707,10 @@ void cyw43_wifi_ap_get_stas(cyw43_t *self, int *num_stas, uint8_t *macs) {
         return;
     }
 
-    cyw43_ll_wifi_ap_get_stas(&self->cyw43_ll, num_stas, macs);
+    ret = cyw43_ll_wifi_ap_get_stas(&self->cyw43_ll, num_stas, macs);
+    if (ret != 0) {
+        *num_stas = 0;
+    }
     CYW43_THREAD_EXIT;
 }
 


### PR DESCRIPTION
- cyw43_ll_wifi_ap_get_stas does not perform checks on the return value of cyw43_get_ioctl. On error (e.g. timeout), invalid num_stas values can be used in the following memcpy call, leading to crashes
- cyw43_ll_wifi_ap_get_stas now returns the return code of cyw43_do_ioctl on error
- Perform bounds checks before using memcpy. This requires the  parameter num_stas to contain the size (in MAC addresses) of the supplied buffer.
- Associated functions in cyw43_ctrl.c set num_stas to 0 on error