### PR TITLE
Add a callback for association of station in AP mode

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -149,6 +149,9 @@ typedef struct _cyw43_t {
     #if CYW43_ENABLE_BLUETOOTH
     bool bt_loaded;
     #endif
+    #if CYW43_ASSOC_CALLBACK
+    void (*assoc_cb)(bool assoc);
+    #endif
 } cyw43_t;
 
 extern cyw43_t cyw43_state;

--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -117,6 +117,9 @@ void cyw43_init(cyw43_t *self) {
     #if CYW43_ENABLE_BLUETOOTH
     self->bt_loaded = false;
     #endif
+    #if CYW43_ASSOC_CALLBACK
+    self->assoc_cb = NULL;
+    #endif
 }
 
 void cyw43_deinit(cyw43_t *self) {
@@ -350,11 +353,23 @@ void cyw43_cb_process_async_event(void *cb_data, const cyw43_async_event_t *ev) 
         cyw43_cb_tcpip_set_link_down(self, CYW43_ITF_STA);
         self->wifi_join_state = 0x0000;
 
-    #if 0
+        // WiFi ap events
+    #if CYW43_ASSOC_CALLBACK
+    } else if (ev->event_type == CYW43_EV_ASSOC_IND) {
+        if (ev->interface == CYW43_ITF_AP) {
+            if (self->assoc_cb) {
+                self->assoc_cb(true);
+            }
+        }
     } else if (ev->event_type == CYW43_EV_DISASSOC_IND) {
         if (ev->interface == CYW43_ITF_AP) {
+    #if 0
             // Station disassociated with our AP, let DHCP server know so it can free the IP address
             dhcp_server_disassoc(&self->dhcp_server, buf + 24);
+    #endif
+            if (self->assoc_cb) {
+                self->assoc_cb(false);
+            }
         }
     #endif
 
@@ -390,10 +405,18 @@ void cyw43_cb_process_async_event(void *cb_data, const cyw43_async_event_t *ev) 
             self->wifi_join_state = WIFI_JOIN_STATE_BADAUTH;
         }
     } else if (ev->event_type == CYW43_EV_DEAUTH_IND) {
-        if (ev->status == 0 && ev->reason == 2) {
-            // Deauth, probably because password was wrong; disassociate
-            self->pend_disassoc = true;
-            cyw43_schedule_internal_poll_dispatch(cyw43_poll_func);
+        if (ev->interface == CYW43_ITF_STA) {
+            if (ev->status == 0 && ev->reason == 2) {
+                // Deauth, probably because password was wrong; disassociate
+                self->pend_disassoc = true;
+                cyw43_schedule_internal_poll_dispatch(cyw43_poll_func);
+            }
+        #if CYW43_ASSOC_CALLBACK
+        } else {
+            if (self->assoc_cb) {
+                self->assoc_cb(false);
+            }
+        #endif
         }
     } else if (ev->event_type == CYW43_EV_LINK) {
         if (ev->status == 0) {

--- a/src/cyw43_ll.h
+++ b/src/cyw43_ll.h
@@ -70,6 +70,7 @@
 #define CYW43_EV_DEAUTH                 (5)
 #define CYW43_EV_DEAUTH_IND             (6)
 #define CYW43_EV_ASSOC                  (7)
+#define CYW43_EV_ASSOC_IND              (8)
 #define CYW43_EV_DISASSOC               (11)
 #define CYW43_EV_DISASSOC_IND           (12)
 #define CYW43_EV_LINK                   (16)


### PR DESCRIPTION
The callback is available when `CYW43_ASSOC_CALLBACK` is defined to 1 and can be used to report when stations are associated or disassociated.