### PR TITLE
updating itf_state when AP gets shut down

### DIFF
--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -564,6 +564,7 @@ void cyw43_wifi_set_up(cyw43_t *self, int itf, bool up, uint32_t country) {
     } else {
         if (itf == CYW43_ITF_AP) {
             cyw43_wifi_ap_set_up(self, false);
+            self->itf_state &= ~(1 << CYW43_ITF_AP);
         }
     }
     CYW43_THREAD_EXIT;


### PR DESCRIPTION
Without this change, it's impossible to get self->itf_state's CYW43_ITF_AP bit cleared.