### PR TITLE
Add section attributes to combined firmware blobs and metadata

### DIFF
--- a/firmware/w43439A0_7_95_49_00_combined.h
+++ b/firmware/w43439A0_7_95_49_00_combined.h
@@ -1,4 +1,4 @@
-static const unsigned char w43439A0_7_95_49_00_combined[] CYW43_RESOURCE_ATTRIBUTE = {
+__attribute__((section(".fw_cyw43.blob"))) static const unsigned char w43439A0_7_95_49_00_combined[] CYW43_RESOURCE_ATTRIBUTE = {
   0x00, 0x00, 0x00, 0x00, 0x65, 0x14, 0x00, 0x00, 0x91, 0x13, 0x00, 0x00,
   0x91, 0x13, 0x00, 0x00, 0x91, 0x13, 0x00, 0x00, 0x91, 0x13, 0x00, 0x00,
   0x91, 0x13, 0x00, 0x00, 0x91, 0x13, 0x00, 0x00, 0x91, 0x13, 0x00, 0x00,
@@ -18772,4 +18772,8 @@ static const unsigned char w43439A0_7_95_49_00_combined[] CYW43_RESOURCE_ATTRIBU
 };
 #define CYW43_WIFI_FW_LEN (224190) // launch_firmware/43439A0.bin
 #define CYW43_CLM_LEN (984) // launch_tuning/43439_raspberrypi_picow_v5_220624.clm_blob
-const uintptr_t fw_data = (uintptr_t)&w43439A0_7_95_49_00_combined[0];
+__attribute__((section(".fw_cyw43.meta"))) const struct cyw43_firmware_data fw_data = {
+    .size = sizeof(w43439A0_7_95_49_00_combined),
+    .wifi_fw_len = CYW43_WIFI_FW_LEN,
+    .addr = (uintptr_t)&w43439A0_7_95_49_00_combined[0],
+};

--- a/firmware/w4343WA1_7_45_98_102_combined.h
+++ b/firmware/w4343WA1_7_45_98_102_combined.h
@@ -1,4 +1,4 @@
-static const unsigned char w4343WA1_7_45_98_102_combined[] CYW43_RESOURCE_ATTRIBUTE = {
+__attribute__((section(".fw_cyw43.blob"))) static const unsigned char w4343WA1_7_45_98_102_combined[] CYW43_RESOURCE_ATTRIBUTE = {
   0x00, 0x00, 0x00, 0x00, 0xed, 0x21, 0x00, 0x00, 0x19, 0x21, 0x00, 0x00,
   0x19, 0x21, 0x00, 0x00, 0x19, 0x21, 0x00, 0x00, 0x19, 0x21, 0x00, 0x00,
   0x19, 0x21, 0x00, 0x00, 0x19, 0x21, 0x00, 0x00, 0x19, 0x21, 0x00, 0x00,
@@ -35719,4 +35719,8 @@ static const unsigned char w4343WA1_7_45_98_102_combined[] CYW43_RESOURCE_ATTRIB
 };
 #define CYW43_WIFI_FW_LEN (421331) // 7.45.98.102
 #define CYW43_CLM_LEN (7222)
-const uintptr_t fw_data = (uintptr_t)&w4343WA1_7_45_98_102_combined[0];
+__attribute__((section(".fw_cyw43.meta"))) const struct cyw43_firmware_data fw_data = {
+    .size = sizeof(w4343WA1_7_45_98_102_combined),
+    .wifi_fw_len = CYW43_WIFI_FW_LEN,
+    .addr = (uintptr_t)&w4343WA1_7_45_98_102_combined[0],
+};

--- a/firmware/w4343WA1_7_45_98_50_combined.h
+++ b/firmware/w4343WA1_7_45_98_50_combined.h
@@ -1,4 +1,4 @@
-static const unsigned char w4343WA1_7_45_98_50_combined[] CYW43_RESOURCE_ATTRIBUTE = {
+__attribute__((section(".fw_cyw43.blob"))) static const unsigned char w4343WA1_7_45_98_50_combined[] CYW43_RESOURCE_ATTRIBUTE = {
   0x00, 0x00, 0x00, 0x00, 0xb1, 0x21, 0x00, 0x00, 0xdd, 0x20, 0x00, 0x00,
   0xdd, 0x20, 0x00, 0x00, 0xdd, 0x20, 0x00, 0x00, 0xdd, 0x20, 0x00, 0x00,
   0xdd, 0x20, 0x00, 0x00, 0xdd, 0x20, 0x00, 0x00, 0xdd, 0x20, 0x00, 0x00,
@@ -32578,4 +32578,8 @@ static const unsigned char w4343WA1_7_45_98_50_combined[] CYW43_RESOURCE_ATTRIBU
 };
 #define CYW43_WIFI_FW_LEN (383110) // 7.45.98.50
 #define CYW43_CLM_LEN (7222)
-const uintptr_t fw_data = (uintptr_t)&w4343WA1_7_45_98_50_combined[0];
+__attribute__((section(".fw_cyw43.meta"))) const struct cyw43_firmware_data fw_data = {
+    .size = sizeof(w4343WA1_7_45_98_50_combined),
+    .wifi_fw_len = CYW43_WIFI_FW_LEN,
+    .addr = (uintptr_t)&w4343WA1_7_45_98_50_combined[0],
+};

--- a/firmware/wb43439A0_7_95_49_00_combined.h
+++ b/firmware/wb43439A0_7_95_49_00_combined.h
@@ -1,4 +1,4 @@
-static const unsigned char wb43439A0_7_95_49_00_combined[] CYW43_RESOURCE_ATTRIBUTE = {
+__attribute__((section(".fw_cyw43.blob"))) static const unsigned char wb43439A0_7_95_49_00_combined[] CYW43_RESOURCE_ATTRIBUTE = {
   0x00, 0x00, 0x00, 0x00, 0x71, 0x14, 0x00, 0x00, 0x9d, 0x13, 0x00, 0x00,
   0x9d, 0x13, 0x00, 0x00, 0x9d, 0x13, 0x00, 0x00, 0x9d, 0x13, 0x00, 0x00,
   0x9d, 0x13, 0x00, 0x00, 0x9d, 0x13, 0x00, 0x00, 0x9d, 0x13, 0x00, 0x00,
@@ -19370,4 +19370,8 @@ static const unsigned char wb43439A0_7_95_49_00_combined[] CYW43_RESOURCE_ATTRIB
 };
 #define CYW43_WIFI_FW_LEN (231077) // bluetooth_firmware_jan2023/43439A0.bin
 #define CYW43_CLM_LEN (984) // launch_tuning/43439_raspberrypi_picow_v5_220624.clm_blob
-const uintptr_t fw_data = (uintptr_t)&wb43439A0_7_95_49_00_combined[0];
+__attribute__((section(".fw_cyw43.meta"))) const struct cyw43_firmware_data fw_data = {
+    .size = sizeof(wb43439A0_7_95_49_00_combined),
+    .wifi_fw_len = CYW43_WIFI_FW_LEN,
+    .addr = (uintptr_t)&wb43439A0_7_95_49_00_combined[0],
+};

--- a/src/cyw43_config.h
+++ b/src/cyw43_config.h
@@ -63,10 +63,15 @@
 #define CYW43_ENABLE_BLUETOOTH (0)
 #endif
 
+struct cyw43_firmware_data {
+    uint32_t size;
+    uint32_t wifi_fw_len;
+    uintptr_t addr;
+};
 // This include should define:
 // - CYW43_WIFI_FW_LEN
 // - CYW43_CLM_LEN
-// - const uintptr_t fw_data
+// - const struct cyw43_firmware_data fw_data
 #ifndef CYW43_CHIPSET_FIRMWARE_INCLUDE_FILE
 #if CYW43_ENABLE_BLUETOOTH
 #define CYW43_CHIPSET_FIRMWARE_INCLUDE_FILE "firmware/wb43439A0_7_95_49_00_combined.h"

--- a/src/cyw43_config.h
+++ b/src/cyw43_config.h
@@ -36,6 +36,9 @@
  * \file
 */
 
+#ifndef _CYW43_CONFIG_H
+#define _CYW43_CONFIG_H
+
 // Import port-specific configuration file.
 #ifdef CYW43_CONFIG_FILE
 #include CYW43_CONFIG_FILE
@@ -170,4 +173,6 @@
 
 #ifndef CYW43_DEFAULT_IP_DNS
 #define CYW43_DEFAULT_IP_DNS LWIP_MAKEU32(8, 8, 8, 8)
+#endif
+
 #endif

--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -71,7 +71,7 @@ extern bool enable_spi_packet_dumping;
 // Include the file containing the WiFi+CLM firmware blob as a C array.
 #include CYW43_CHIPSET_FIRMWARE_INCLUDE_FILE
 
-#define CYW43_CLM_ADDR (fw_data + ALIGN_UINT(CYW43_WIFI_FW_LEN, 512))
+#define CYW43_CLM_ADDR (fw_data.addr + ALIGN_UINT(fw_data.wifi_fw_len, 512))
 #define VERIFY_FIRMWARE_DOWNLOAD (0)
 
 #define ALIGN_UINT(val, align) (((val) + (align) - 1) & ~((align) - 1))
@@ -1660,7 +1660,7 @@ alp_set:
     cyw43_write_backplane(self, SOCSRAM_BANKX_PDA, 4, 0);
 
     // Download the main WiFi firmware blob to the 43xx device.
-    int ret = cyw43_download_resource(self, 0x00000000, CYW43_WIFI_FW_LEN, 0, fw_data);
+    int ret = cyw43_download_resource(self, 0x00000000, fw_data.wifi_fw_len, 0, fw_data.addr);
     if (ret != 0) {
         return ret;
     }


### PR DESCRIPTION
This change will not do much for regular builds, but it allows to put the firmware blob in a specific flash area.

In cases where multiple firmware versions run on the same device, this allows re-use of the firmware blob. On such case is picowota, the Raspberry Pi Pico W OTA flash bootloader. Until now, picowota users effectively have the firmware on their devices twice.

Another use case is that in a firmware update, the CYW firmware can be left untouched.

The pointer to the blob is put in a struct that also contains some metadata, which is put in a separate section to allow linker script writers to prepend the binary blob with something like a header.

To store the cyw firmware at a particular location in flash, these changes can be made to the linker script:

```
MEMORY {
...
   FLASH_FW_CYW(rx):            ORIGIN = 0x10040000, LENGTH = 256k
...
}
```

and

```
SECTIONS {
...
    .fw_cyw43 : { 
        . = ALIGN(4k);
        KEEP(*(.fw_cyw43.meta))
        . = ALIGN(512);
        *(.fw_cyw43.blob)
    } > FLASH_FW_CYW
...
}
```

(edit: renamed flash memory and section to `FLASH_FW_CYW` and `.fw_cyw43`)