### PR TITLE
src/cyw43_ll: Replace "__uint16_t" with "uint16_t"

### DIFF
--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -1114,7 +1114,7 @@ static int cyw43_ll_sdpcm_poll_device(cyw43_int_t *self, size_t *len, uint8_t **
     }
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wcast-align"
-    uint16_t *hdr = (__uint16_t *)self->spid_buf;
+    uint16_t *hdr = (uint16_t *)self->spid_buf;
     #pragma GCC diagnostic pop
     if (hdr[0] == 0 && hdr[1] == 0) {
         // no packets


### PR DESCRIPTION
This patch replaces "__uint16_t" with "uint16_t" to fix a build issue
when using non-gcc toolchain. "__uint16_t" is not a standard C type
and it will fail to build when using toolchains like Clang.
