### PR TITLE
src/cyw43_lwip: Use NETIF_FOREACH to iterate over all netif's.

### DIFF
--- a/src/cyw43_lwip.c
+++ b/src/cyw43_lwip.c
@@ -251,7 +251,8 @@ void cyw43_cb_tcpip_deinit(cyw43_t *self, int itf) {
         dhcp_server_deinit(&self->dhcp_server);
         #endif
     }
-    for (struct netif *netif = netif_list; netif != NULL; netif = netif->next) {
+    struct netif *netif;
+    NETIF_FOREACH(netif) {
         if (netif == n) {
             netif_remove(netif);
             #if LWIP_IPV4


### PR DESCRIPTION
Using this macro means the code works correctly when LWIP_SINGLE_NETIF is enabled.

Fixes issue #124.