### PR TITLE
src/cyw43: Improve power-save constants so their names match behaviour.

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -209,6 +209,7 @@ int cyw43_send_ethernet(cyw43_t *self, int itf, size_t len, const void *buf, boo
  *
  * \see cyw43_pm_value
  * \see CYW43_DEFAULT_PM
+ * \see CYW43_NONE_PM
  * \see CYW43_AGGRESSIVE_PM
  * \see CYW43_PERFORMANCE_PM
  *
@@ -612,6 +613,7 @@ int cyw43_gpio_get(cyw43_t *self, int gpio, bool *val);
  * CYW43_PM2_POWERSAVE_MODE | Power saving with High throughput (preferred). Saves power when there is no wifi activity for some time.
  *
  * \see \ref CYW43_DEFAULT_PM
+ * \see \ref CYW43_NONE_PM
  * \see \ref CYW43_AGGRESSIVE_PM
  * \see \ref CYW43_PERFORMANCE_PM
  *
@@ -633,17 +635,22 @@ static inline uint32_t cyw43_pm_value(uint8_t pm_mode, uint16_t pm2_sleep_ret_ms
 /*!
  * \brief Default power management mode
  */
-#define CYW43_DEFAULT_PM cyw43_pm_value(CYW43_PM2_POWERSAVE_MODE, 200, 1, 1, 10)
+#define CYW43_DEFAULT_PM (CYW43_PERFORMANCE_PM)
+
+/*!
+ * \brief No power management
+ */
+#define CYW43_NONE_PM (cyw43_pm_value(CYW43_NO_POWERSAVE_MODE, 10, 0, 0, 0))
 
 /*!
  * \brief Aggressive power management mode for optimal power usage at the cost of performance
  */
-#define CYW43_AGGRESSIVE_PM cyw43_pm_value(CYW43_PM2_POWERSAVE_MODE, 2000, 1, 1, 10)
+#define CYW43_AGGRESSIVE_PM (cyw43_pm_value(CYW43_PM1_POWERSAVE_MODE, 10, 0, 0, 0))
 
 /*!
  * \brief Performance power management mode where more power is used to increase performance
  */
-#define CYW43_PERFORMANCE_PM cyw43_pm_value(CYW43_PM2_POWERSAVE_MODE, 20, 1, 1, 1)
+#define CYW43_PERFORMANCE_PM (cyw43_pm_value(CYW43_PM2_POWERSAVE_MODE, 200, 1, 1, 10))
 
 #if CYW43_ENABLE_BLUETOOTH
 /*!


### PR DESCRIPTION
Doing some testing with various power saving modes gives the following:
- CYW43_NO_POWERSAVE_MODE costs about 36mA in idle STA mode while connected to an AP (the cyw43xx stays on during idle).
- CYW43_PM1_POWERSAVE_MODE and CYW43_PM2_POWERSAVE_MODE cost about 2mA in idle STA mode while connected to an AP.

For all three of the pre-defined constants `CYW43_DEFAULT_PM`, `CYW43_AGGRESSIVE_PM` and `CYW43_PERFORMANCE_PM`, doing a fast `ping -i 0.1 <ip>` to the cyw43, there's pretty much no difference (they all have low latency).  That's because they all use `CYW43_PM2_POWERSAVE_MODE` and the fast ping is supplying constant traffic over the air and keeping the cyw43 awake.

Doing a standard 1-second interval ping its possible to see the difference between these three pre-defined constants: `CYW43_AGGRESSIVE_PM` still has low latency, but the other two have very varied ping latency, up to about 200ms (because the cyw43 has gone to sleep and takes time to wake up).

So the names of these three pre-defined constants don't match their behaviour very well, and they aren't very different in their behaviour.

This is fixed in this commit by adjusting the power-save settings so the names of the constants match their behaviour.

Also a new `CYW43_NONE_PM` has been added.

Note that `CYW43_DEFAULT_PM` still has exactly the same behaviour as it did prior to this commit.

Fixes issue #122.