### PR TITLE
github/workflows: Pin code formatting to ubuntu-22.04 for uncrustify.

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -8,7 +8,8 @@ concurrency:
 
 jobs:
   code-formatting:
-    runs-on: ubuntu-latest
+    # Pin to ubuntu-22.04 to get the correct version of uncrustify.
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION
ubuntu-latest recently changed to 24.04, which changed uncrustify, so pin it to the previous version to get the correct formatting (until the uncrustify configuration is updated).