### PR TITLE
src/cyw43_ctrl: Implement roaming configuration

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -361,6 +361,63 @@ int cyw43_wifi_join(cyw43_t *self, size_t ssid_len, const uint8_t *ssid, size_t 
 int cyw43_wifi_leave(cyw43_t *self, int itf);
 
 /*!
+ * \brief Enable or disable WiFi roaming on the STA interface
+ *
+ * When disabled, the firmware will remain associated to its current AP
+ * regardless of signal strength. When enabled, roaming behaviour is
+ * governed by the parameters set in \c cyw43_wifi_set_roam_params.
+ *
+ * Roaming is enabled by default. 
+ *
+ * \param self     The driver state object, always \c &cyw43_state
+ * \param enabled  true to enable roaming, false to disable
+ * \return 0 on success, negative error code on failure
+ */
+int cyw43_wifi_set_roam_enabled(cyw43_t *self, bool enabled);
+
+/*!
+ * \brief Configure WiFi roaming parameters for the STA interface
+ *
+ * Controls when the firmware will scan for and switch to a better AP.
+ * Roaming is a STA-mode only feature - these parameters have no effect
+ * when called on the AP interface.
+ *
+ * The firmware begins scanning for alternative APs when the current AP's
+ * RSSI drops below \p trigger_dbm. A candidate AP must have an RSSI at
+ * least \p candidate_delta_db higher than the current AP before the
+ * firmware will roam to it. This prevents thrashing between APs of
+ * similar signal strength.
+ *
+ * \param self          The driver state object, always \c &cyw43_state
+ * \param trigger_dbm   RSSI threshold in dBm below which roam scanning begins.
+ *                      Typical value: -75. Must be negative.
+ * \param candidate_delta_db  Minimum RSSI improvement in dB a candidate AP
+ *                      must offer over the current AP to trigger a roam.
+ *                      Typical value: 10.
+ * \param scan_period_ms How often in milliseconds the firmware scans for better
+ *                      APs while below the trigger threshold.
+ * \return 0 on success, negative error code on failure
+ */
+int cyw43_wifi_set_roam_params(cyw43_t *self, int trigger_dbm, int candidate_delta_db, int scan_period_ms);
+
+/*!
+ * \brief Retrieve the current WiFi roaming parameters for the STA interface
+ *
+ * Reads back the roaming parameters that are currently set.
+ * Any pointer may be NULL if that parameter is not required.
+ *
+ * \param self                The driver state object, always \c &cyw43_state
+ * \param trigger_dbm         Output: RSSI threshold in dBm below which roam
+ *                            scanning begins. Will be a negative value.
+ * \param candidate_delta_db  Output: Minimum RSSI improvement in dB a candidate
+ *                            AP must offer over the current AP to trigger a roam.
+ * \param scan_period_ms      Output: How often in milliseconds the firmware scans
+ *                            for better APs while below the trigger threshold.
+ * \return 0 on success, negative error code on failure
+ */
+int cyw43_wifi_get_roam_params(cyw43_t *self, int *trigger_dbm, int *candidate_delta_db, int *scan_period_ms);
+
+/*!
  * \brief Get the signal strength (RSSI) of the wifi network
  *
  * For STA (client) mode, returns the signal strength or RSSI of the wifi network.

--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -668,6 +668,65 @@ int cyw43_wifi_leave(cyw43_t *self, int itf) {
     return cyw43_ioctl(self, CYW43_IOCTL_SET_DISASSOC, 0, NULL, itf);
 }
 
+int cyw43_wifi_set_roam_enabled(cyw43_t *self, bool enabled)
+{
+    CYW43_THREAD_ENTER;
+    if (!CYW43_STA_IS_ACTIVE(self)) {
+        CYW43_THREAD_EXIT;
+        return -CYW43_EPERM;
+    }
+
+    int ret = cyw43_ensure_up(self);
+    if (ret) {
+        CYW43_THREAD_EXIT;
+        return ret;
+    }
+
+    ret = cyw43_ll_wifi_set_roam_enabled(&self->cyw43_ll, enabled);
+
+    CYW43_THREAD_EXIT;
+    return ret;
+}
+
+int cyw43_wifi_set_roam_params(cyw43_t *self, int trigger_dbm, int candidate_delta_db, int scan_period_ms)
+{
+    CYW43_THREAD_ENTER;
+    if (!CYW43_STA_IS_ACTIVE(self)) {
+        CYW43_THREAD_EXIT;
+        return -CYW43_EPERM;
+    }
+
+    int ret = cyw43_ensure_up(self);
+    if (ret) {
+        CYW43_THREAD_EXIT;
+        return ret;
+    }
+
+    ret = cyw43_ll_wifi_set_roam_params(&self->cyw43_ll, trigger_dbm, candidate_delta_db, scan_period_ms);
+
+    CYW43_THREAD_EXIT;
+    return ret;
+}
+
+int cyw43_wifi_get_roam_params(cyw43_t *self, int *trigger_dbm, int *candidate_delta_db, int *scan_period_ms)
+{
+    CYW43_THREAD_ENTER;
+    if (!CYW43_STA_IS_ACTIVE(self)) {
+        CYW43_THREAD_EXIT;
+        return -CYW43_EPERM;
+    }
+
+    int ret = cyw43_ensure_up(self);
+    if (ret) {
+        CYW43_THREAD_EXIT;
+        return ret;
+    }
+
+    ret = cyw43_ll_wifi_get_roam_params(&self->cyw43_ll, trigger_dbm, candidate_delta_db, scan_period_ms);
+
+    CYW43_THREAD_EXIT;
+    return ret;
+}
 
 int cyw43_wifi_get_rssi(cyw43_t *self, int32_t *rssi) {
     if (!rssi || !CYW43_STA_IS_ACTIVE(self)) {

--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -196,6 +196,12 @@ static void cyw43_xxd(size_t len, const uint8_t *buf) {
 #define WLC_SET_SSID (26)
 #define WLC_SET_CHANNEL (30)
 #define WLC_DISASSOC (52)
+#define WLC_GET_ROAM_TRIGGER (54)
+#define WLC_SET_ROAM_TRIGGER (55)
+#define WLC_GET_ROAM_DELTA (56)
+#define WLC_SET_ROAM_DELTA (57)
+#define WLC_GET_ROAM_SCAN_PERIOD (58)
+#define WLC_SET_ROAM_SCAN_PERIOD (59)
 #define WLC_GET_ANTDIV (63)
 #define WLC_SET_ANTDIV (64)
 #define WLC_SET_DTIMPRD (78)
@@ -1972,6 +1978,55 @@ int cyw43_ll_wifi_update_multicast_filter(cyw43_ll_t *self_in, uint8_t *addr, bo
     // write back address list
     cyw43_write_iovar_n(self, "mcast_list", 4 + MAX_MULTICAST_REGISTERED_ADDRESS * 6, buf, WWD_STA_INTERFACE);
     cyw43_delay_ms(50);
+
+    return 0;
+}
+
+int cyw43_ll_wifi_set_roam_enabled(cyw43_ll_t *self_in, bool enabled)
+{
+    cyw43_int_t *self = CYW_INT_FROM_LL(self_in);
+
+    cyw43_write_iovar_u32(self, "roam_off", enabled ? 0 : 1, WWD_STA_INTERFACE);
+
+    #if 0
+    CYW43_PRINTF("roam_off: %lu\n", cyw43_read_iovar_u32(self, "roam_off", WWD_STA_INTERFACE));
+    #endif
+
+    return 0;
+}
+
+int cyw43_ll_wifi_set_roam_params(cyw43_ll_t *self_in, int trigger_dbm, int candidate_delta_db, int scan_period_ms)
+{
+    cyw43_int_t *self = CYW_INT_FROM_LL(self_in);
+
+    cyw43_set_ioctl_u32(self, WLC_SET_ROAM_TRIGGER, (uint32_t)trigger_dbm, WWD_STA_INTERFACE);
+    cyw43_set_ioctl_u32(self, WLC_SET_ROAM_DELTA, (uint32_t)candidate_delta_db, WWD_STA_INTERFACE);
+    cyw43_set_ioctl_u32(self, WLC_SET_ROAM_SCAN_PERIOD, (uint32_t)scan_period_ms, WWD_STA_INTERFACE);
+
+    #if 0
+    CYW43_PRINTF("roam_trigger: %d\n", (int32_t)cyw43_get_ioctl_u32(self, WLC_GET_ROAM_TRIGGER, WWD_STA_INTERFACE));
+    CYW43_PRINTF("roam_delta: %d\n", (int32_t)cyw43_get_ioctl_u32(self, WLC_GET_ROAM_DELTA, WWD_STA_INTERFACE));
+    CYW43_PRINTF("roam_scan_period: %d\n", (int32_t)cyw43_get_ioctl_u32(self, WLC_GET_ROAM_SCAN_PERIOD, WWD_STA_INTERFACE));
+    #endif
+
+    return 0;
+}
+
+int cyw43_ll_wifi_get_roam_params(cyw43_ll_t *self_in, int *trigger_dbm, int *candidate_delta_db, int *scan_period_ms)
+{
+    cyw43_int_t *self = CYW_INT_FROM_LL(self_in);
+
+    if (trigger_dbm) {
+        *trigger_dbm = (int32_t)cyw43_get_ioctl_u32(self, WLC_GET_ROAM_TRIGGER, WWD_STA_INTERFACE);
+    }
+
+    if (candidate_delta_db) {
+        *candidate_delta_db = (int32_t)cyw43_get_ioctl_u32(self, WLC_GET_ROAM_DELTA, WWD_STA_INTERFACE);
+    }
+
+    if (scan_period_ms) {
+        *scan_period_ms = (int32_t)cyw43_get_ioctl_u32(self, WLC_GET_ROAM_SCAN_PERIOD, WWD_STA_INTERFACE);
+    }
 
     return 0;
 }

--- a/src/cyw43_ll.h
+++ b/src/cyw43_ll.h
@@ -281,6 +281,10 @@ int cyw43_ll_wifi_pm(cyw43_ll_t *self, uint32_t pm, uint32_t pm_sleep_ret, uint3
 int cyw43_ll_wifi_get_pm(cyw43_ll_t *self, uint32_t *pm, uint32_t *pm_sleep_ret, uint32_t *li_bcn, uint32_t *li_dtim, uint32_t *li_assoc);
 int cyw43_ll_wifi_scan(cyw43_ll_t *self, cyw43_wifi_scan_options_t *opts);
 
+int cyw43_ll_wifi_set_roam_enabled(cyw43_ll_t *self_in, bool enabled);
+int cyw43_ll_wifi_set_roam_params(cyw43_ll_t *self_in, int trigger_dbm, int candidate_delta_db, int scan_period_ms);
+int cyw43_ll_wifi_get_roam_params(cyw43_ll_t *self_in, int *trigger_dbm, int *candidate_delta_db, int *scan_period_ms);
+
 int cyw43_ll_wifi_join(cyw43_ll_t *self, size_t ssid_len, const uint8_t *ssid, size_t key_len, const uint8_t *key, uint32_t auth_type, const uint8_t *bssid, uint32_t channel);
 void cyw43_ll_wifi_set_wpa_auth(cyw43_ll_t *self);
 void cyw43_ll_wifi_rejoin(cyw43_ll_t *self);


### PR DESCRIPTION
Add ctrl and ll functions to configure and query WiFi roaming behavior on the STA.

Why? Until now, this has been enabled by default with no option to configure/alter the behavior. If a device drops below the trigger threshold for RSSI, it would drop packets due to activating roam.

interface:

- cyw43_ll_wifi_set_roam_enabled / cyw43_wifi_set_roam_enabled
  Control the roam_off iovar to enable or disable roaming entirely.

- cyw43_ll_wifi_set_roam_params / cyw43_wifi_set_roam_params
  Set the RSSI trigger threshold, candidate delta, and scan period.

- cyw43_ll_wifi_get_roam_params / cyw43_wifi_get_roam_params
  Read back current roam parameters. All output pointers are nullable.
