### PR TITLE
src/cyw43_ctrl: Implement interference mode configuration

### DIFF
--- a/src/cyw43.h
+++ b/src/cyw43.h
@@ -104,6 +104,20 @@
 #define CYW43_LINK_BADAUTH      (-3)    ///< Authenticatation failure
 //!\}
 
+/*!
+ * \name Interference mitigation mode
+ * \anchor CYW43_IFMODE_
+ * \see cyw43_wifi_interference_mode_set() to set the mitigation mode
+ * \see cyw43_wifi_interference_mode_get() to get the mitigation mode
+ */
+//!\{
+#define CYW43_IFMODE_NONE         (0)     ///< None/Disabled
+#define CYW43_IFMODE_NONWLAN      (1)     ///< Non-WLAN
+#define CYW43_IFMODE_WLANMANUAL   (2)     ///< Adjacent channel interference (ACI) mode
+#define CYW43_IFMODE_AUTO         (3)     ///< Automatic as determined by driver (ACI)
+#define CYW43_IFMODE_AUTONOISE    (4)     ///< Automatic as determined by driver with noise reduction (ACI)
+//!\}
+
 typedef struct _cyw43_t {
     cyw43_ll_t cyw43_ll;
 
@@ -199,6 +213,31 @@ int cyw43_ioctl(cyw43_t *self, uint32_t cmd, size_t len, uint8_t *buf, uint32_t 
  * \return 0 on success
  */
 int cyw43_send_ethernet(cyw43_t *self, int itf, size_t len, const void *buf, bool is_pbuf);
+
+/*!
+ * \brief Set the WiFi interference mitigation mode
+ *
+ * Controls how aggressively the firmware attempts to mitigate interference
+ * on the 2.4GHz band. Higher modes reduce interference at the cost of
+ * RX sensitivity, which can be detrimental to long range operation.
+ *
+ * \note This setting applies globally to the radio and affects both the
+ * STA and AP interfaces in apsta mode.
+ *
+ * \param self  The driver state object, always \c &cyw43_state
+ * \param mode  Interference mitigation mode, one of \ref CYW43_IFMODE_
+ * \return 0 on success, negative error code on failure
+ */
+int cyw43_wifi_set_interference_mode(cyw43_t *self, uint32_t mode);
+
+/*!
+ * \brief Get the current WiFi interference mitigation mode
+ *
+ * \param self  The driver state object, always \c &cyw43_state
+ * \param mode  Output: current interference mitigation mode, one of \ref CYW43_IFMODE_
+ * \return 0 on success, negative error code on failure
+ */
+int cyw43_wifi_get_interference_mode(cyw43_t *self, uint32_t *mode);
 
 /*!
  * \brief Set the wifi power management mode

--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -491,6 +491,41 @@ static int cyw43_wifi_on(cyw43_t *self, uint32_t country) {
     return ret;
 }
 
+int cyw43_wifi_set_interference_mode(cyw43_t *self, uint32_t mode)
+{
+    CYW43_THREAD_ENTER;
+    int ret = cyw43_ensure_up(self);
+    if (ret) {
+        CYW43_THREAD_EXIT;
+        return ret;
+    }
+
+    ret = cyw43_ll_wifi_set_interference_mode(&self->cyw43_ll, mode);
+
+    CYW43_THREAD_EXIT;
+    return ret;
+}
+
+int cyw43_wifi_get_interference_mode(cyw43_t *self, uint32_t *mode)
+{
+    CYW43_THREAD_ENTER;
+    if (!mode) {
+        CYW43_THREAD_EXIT;
+        return -CYW43_EINVAL;
+    }
+
+    int ret = cyw43_ensure_up(self);
+    if (ret) {
+        CYW43_THREAD_EXIT;
+        return ret;
+    }
+
+    ret = cyw43_ll_wifi_get_interference_mode(&self->cyw43_ll, mode);
+
+    CYW43_THREAD_EXIT;
+    return ret;
+}
+
 int cyw43_wifi_pm(cyw43_t *self, uint32_t pm_in) {
     CYW43_THREAD_ENTER;
     int ret = cyw43_ensure_up(self);

--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -206,6 +206,8 @@ static void cyw43_xxd(size_t len, const uint8_t *buf) {
 #define WLC_SET_BAND (142)
 #define WLC_GET_ASSOCLIST (159)
 #define WLC_SET_WPA_AUTH (165)
+#define WLC_GET_INTERFERENCE_MODE (211)
+#define WLC_SET_INTERFERENCE_MODE (212)
 #define WLC_SET_VAR (263)
 #define WLC_GET_VAR (262)
 #define WLC_SET_WSEC_PMK (268)
@@ -1972,6 +1974,29 @@ int cyw43_ll_wifi_update_multicast_filter(cyw43_ll_t *self_in, uint8_t *addr, bo
     // write back address list
     cyw43_write_iovar_n(self, "mcast_list", 4 + MAX_MULTICAST_REGISTERED_ADDRESS * 6, buf, WWD_STA_INTERFACE);
     cyw43_delay_ms(50);
+
+    return 0;
+}
+
+int cyw43_ll_wifi_set_interference_mode(cyw43_ll_t *self_in, uint32_t mode)
+{
+    cyw43_int_t *self = CYW_INT_FROM_LL(self_in);
+
+    cyw43_set_ioctl_u32(self, WLC_SET_INTERFERENCE_MODE, mode, WWD_STA_INTERFACE);
+
+    #if 0
+    CYW43_PRINTF("interference_mode: %lu\n", cyw43_get_ioctl_u32(self, WLC_GET_INTERFERENCE_MODE, WWD_STA_INTERFACE));
+    #endif
+
+    return 0;
+}
+
+int cyw43_ll_wifi_get_interference_mode(cyw43_ll_t *self_in, uint32_t *mode)
+{
+    cyw43_int_t *self = CYW_INT_FROM_LL(self_in);
+
+    assert(mode);
+    *mode = cyw43_get_ioctl_u32(self, WLC_GET_INTERFERENCE_MODE, WWD_STA_INTERFACE);
 
     return 0;
 }

--- a/src/cyw43_ll.h
+++ b/src/cyw43_ll.h
@@ -276,6 +276,9 @@ void cyw43_ll_process_packets(cyw43_ll_t *self);
 int cyw43_ll_ioctl(cyw43_ll_t *self, uint32_t cmd, size_t len, uint8_t *buf, uint32_t iface);
 int cyw43_ll_send_ethernet(cyw43_ll_t *self, int itf, size_t len, const void *buf, bool is_pbuf);
 
+int cyw43_ll_wifi_set_interference_mode(cyw43_ll_t *self_in, uint32_t mode);
+int cyw43_ll_wifi_get_interference_mode(cyw43_ll_t *self_in, uint32_t *mode);
+
 int cyw43_ll_wifi_on(cyw43_ll_t *self, uint32_t country);
 int cyw43_ll_wifi_pm(cyw43_ll_t *self, uint32_t pm, uint32_t pm_sleep_ret, uint32_t li_bcn, uint32_t li_dtim, uint32_t li_assoc);
 int cyw43_ll_wifi_get_pm(cyw43_ll_t *self, uint32_t *pm, uint32_t *pm_sleep_ret, uint32_t *li_bcn, uint32_t *li_dtim, uint32_t *li_assoc);


### PR DESCRIPTION
Add functions to configure and query the WiFi interference mitigation
mode:

- cyw43_ll_wifi_set_interference_mode / cyw43_wifi_set_interference_mode
- cyw43_ll_wifi_get_interference_mode / cyw43_wifi_get_interference_mode

The mode is controlled via the WLC_SET/GET_INTERFERENCE_MODE ioctls and
accepts one of the CYW43_IFMODE_ constants:

  CYW43_IFMODE_NONE        (0) - disabled
  CYW43_IFMODE_NONWLAN     (1) - non-WLAN interference mitigation
  CYW43_IFMODE_WLANMANUAL  (2) - adjacent channel interference (ACI)
  CYW43_IFMODE_AUTO        (3) - automatic ACI
  CYW43_IFMODE_AUTONOISE   (4) - automatic ACI with noise reduction

Unlike the roam APIs, interference mode applies globally to the radio
and is not gated on STA_IS_ACTIVE as it affects both STA and AP
interfaces in apsta mode.

Info was found at: https://community.infineon.com/gfawx74859/attachments/gfawx74859/twwifibtcombo/869/1/wl_002-23156.pdf
