### PR TITLE
src: Improve "bad auth" problems.

### DIFF
--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -378,6 +378,7 @@ void cyw43_cb_process_async_event(void *cb_data, const cyw43_async_event_t *ev) 
             // No matching SSID found (could be out of range, or down)
         } else {
             // Other failure setting SSID
+            CYW43_DEBUG("link error status %d\n", ev->status);
             self->wifi_join_state = WIFI_JOIN_STATE_FAIL;
         }
     } else if (ev->event_type == CYW43_EV_AUTH) {
@@ -387,10 +388,14 @@ void cyw43_cb_process_async_event(void *cb_data, const cyw43_async_event_t *ev) 
                 self->wifi_join_state = (self->wifi_join_state & ~WIFI_JOIN_STATE_KIND_MASK) | WIFI_JOIN_STATE_ACTIVE;
             }
             self->wifi_join_state |= WIFI_JOIN_STATE_AUTH;
-        } else if (ev->status == 6) {
-            // Unsolicited auth packet, ignore it
+        } else if (ev->status == 6 || ev->status == 2 || ev->status == 5) {
+            // 2 = Timeout
+            // 5 = No ack
+            // 6 = Unsolicited auth packet
+            // Ignore it, lets keep trying
         } else {
             // Cannot authenticate
+            CYW43_DEBUG("auth error status %d\n", ev->status);
             self->wifi_join_state = WIFI_JOIN_STATE_BADAUTH;
         }
     } else if (ev->event_type == CYW43_EV_DEAUTH_IND) {
@@ -423,6 +428,7 @@ void cyw43_cb_process_async_event(void *cb_data, const cyw43_async_event_t *ev) 
             cyw43_schedule_internal_poll_dispatch(cyw43_poll_func);
         } else {
             // PSK_SUP failure
+            CYW43_DEBUG("auth psk status %d\n", ev->status);
             self->wifi_join_state = WIFI_JOIN_STATE_BADAUTH;
         }
     } else if (ev->event_type == CYW43_EV_ICV_ERROR) {


### PR DESCRIPTION
This is a speculative improvement for issues some users seem to see with connecting a Pico to an access point.
Today for some reason the WiFi environment in our office is terrible and I'm seeing a lot of connection problems.
These all show up as "auth failure" as if the WiFi credentials are wrong.
Ignoring "Timeout" and "No ack" status seems to improve reliability.