### PR TITLE
src/cyw43_ctrl: Lock the bus across BT HCI read/write

### DIFF
--- a/src/cyw43_ctrl.c
+++ b/src/cyw43_ctrl.c
@@ -782,30 +782,39 @@ int cyw43_bluetooth_hci_init(void) {
 // Read data
 int cyw43_bluetooth_hci_read(uint8_t *buf, uint32_t max_size, uint32_t *len) {
     cyw43_t *self = &cyw43_state;
+    // Hold the bus lock across the whole transfer: the BT shared bus runs over
+    // the same gSPI/SDIO backplane as WiFi, so a caller that does not already
+    // serialise against WiFi (i.e. anything other than the btstack transport)
+    // would otherwise interleave WiFi and BT transfers on the bus.
+    CYW43_THREAD_ENTER;
     int ret = cyw43_ensure_bt_up(self);
     if (ret) {
+        CYW43_THREAD_EXIT;
         return ret;
     }
     ret = cyw43_btbus_read(buf, max_size, len);
     if (ret) {
         CYW43_PRINTF("cyw43_bluetooth_hci_read: failed to read from shared bus\n");
-        return ret;
     }
-    return 0;
+    CYW43_THREAD_EXIT;
+    return ret;
 }
 
 // Write data, buffer needs to include space for a 4 byte header and include this in len
 int cyw43_bluetooth_hci_write(uint8_t *buf, size_t len) {
     cyw43_t *self = &cyw43_state;
+    // See cyw43_bluetooth_hci_read: hold the bus lock across the whole transfer.
+    CYW43_THREAD_ENTER;
     int ret = cyw43_ensure_bt_up(self);
     if (ret) {
+        CYW43_THREAD_EXIT;
         return ret;
     }
     ret = cyw43_btbus_write(buf, len);
     if (ret) {
         CYW43_PRINTF("cyw43_bluetooth_hci_write: failed to write to shared bus\n");
-        return ret;
     }
-    return 0;
+    CYW43_THREAD_EXIT;
+    return ret;
 }
 #endif


### PR DESCRIPTION
## What

`cyw43_bluetooth_hci_read()` and `cyw43_bluetooth_hci_write()` call `cyw43_btbus_read()` / `cyw43_btbus_write()` without holding the cyw43 bus lock. The BT shared bus runs over the same gSPI/SDIO backplane as WiFi, so a caller that does not already serialise against WiFi will interleave WiFi and BT transfers on the bus.

This change takes `CYW43_THREAD_ENTER` across the whole transfer so the two functions are self-serialising.

## Why

The btstack HCI transport in pico-sdk happens to wrap these calls in `CYW43_THREAD_ENTER`/`CYW43_THREAD_EXIT` itself (`btstack_hci_transport_cyw43.c`), so **the stock pico-sdk + BTstack path is unaffected** by this change. But any other consumer that calls the BT HCI API directly — a non-btstack integration, or a multi-threaded port where WiFi and BT run on separate threads — is left unprotected and can interleave bus transfers.

The lock is recursive, so the existing wrapping in the btstack transport and the nested `cyw43_ensure_bt_up()` continue to work unchanged. Behaviour is identical on the happy path; this only adds serialisation for direct callers.

## Context

This came out of a downstream Zephyr WiFi+BLE coexistence effort on the CYW43439 (gSPI), where WiFi and BT run as separate threads. The missing lock here let BT HCI transfers race the WiFi poll thread on the shared bus. Discussion and a related transport-robustness fix (re-read of transiently corrupt ring indices) are in raspberrypi/pico-sdk#3027; the broader effort is tracked in the Zephyr RFC zephyrproject-rtos/zephyr#111811.

Suggested by @peterharperuk in raspberrypi/pico-sdk#3027.

## Testing

Builds clean under the repo host tests (`tests/sdio` compiles `cyw43_ctrl.c`) and `-Werror -fsyntax-only` with `CYW43_ENABLE_BLUETOOTH=1`. Functionally verified on hardware (Pico 2 W) as part of the Zephyr coex port: with the bus held across BT transfers, WiFi+BLE ran a 2-hour soak with zero faults.
