### PR TITLE
src/cyw43_ll: call cyw43_write_bytes() with the real buffer size

### DIFF
--- a/src/cyw43_ll.c
+++ b/src/cyw43_ll.c
@@ -712,8 +712,15 @@ static int cyw43_sdpcm_send_common(cyw43_int_t *self, uint32_t kind, size_t len,
 
     self->wwd_sdpcm_packet_transmit_sequence_number += 1;
 
+    #if CYW43_USE_SPI
+    // cyw43_write_bytes will pad the data to 4-byte alignment for the
+    // SPI transfer, but the actual payload size is encoded in the
+    // header word
+    return cyw43_write_bytes(self, WLAN_FUNCTION, 0, size, buf);
+    #else
     // padding is taken from junk at end of buffer
     return cyw43_write_bytes(self, WLAN_FUNCTION, 0, CYW43_WRITE_BYTES_PAD(size), buf);
+    #endif
 }
 
 struct ioctl_header_t {


### PR DESCRIPTION
When `cyw43_sdpcm_send_common()` calls `cyw43_write_bytes()` to send a packet via SPI or SDIO, it accounts for the transport-specific padding when calling the function. That means that the underlying implementation of `cyw43_write_bytes()` receives the padded length and can't know the original buffer size.

[An implementation for SPI](https://github.com/georgerobotics/cyw43-driver/blob/055d64274b014dd7b1c2fc94d26e8a18face7124/src/cyw43_spi.c#L120) will use that padded length to build the SPI command, which will eventually cause the chip to emit the packet to the air with any trailing padding bytes added to it.

Padding the buffer should be a responsibility of the specific `cyw43_write_bytes()` implementation, and `cyw43_sdpcm_send_common()` should provide the original size of the buffer.

## Example:

Original buffer generated by the application (65 bytes):

```
0x20037640 <malloc_arena+43480>:        0x17    0xfe    0xfd    0x00    0x01    0x00    0x00    0x00
0x20037648 <malloc_arena+43488>:        0x00    0x00    0x13    0x00    0x34    0x00    0x01    0x00
0x20037650 <malloc_arena+43496>:        0x00    0x00    0x00    0x00    0x13    0xba    0x17    0x44
0x20037658 <malloc_arena+43504>:        0x83    0xb8    0xbc    0x2c    0x8f    0xeb    0x80    0x39
0x20037660 <malloc_arena+43512>:        0x1b    0x2d    0x3f    0x43    0x32    0x4c    0xc9    0x7a
0x20037668 <malloc_arena+43520>:        0x83    0x5e    0x8f    0xa6    0xfd    0x2a    0xb9    0x3b
0x20037670 <malloc_arena+43528>:        0x91    0x6f    0x01    0x81    0x14    0xf8    0xc9    0xb1
0x20037678 <malloc_arena+43536>:        0xb0    0x65    0x5b    0xfb    0x73    0x7a    0xac    0x90
0x20037680 <malloc_arena+43544>:        0x9d
```

By the time the buffer reaches `cyw43_sdpcm_send_common()`, it includes the additional UDP, IP and Ethernet headers, and `cyw43_sdpcm_send_common()` receives it as a 113 byte buffer. It then adds the SDPCM header (12 bytes). The resulting buffer is this (the payload starts at buf[18] = 0x90):

```
0x20017440 <cyw43_state+40>:    0x04    0x01    0xfb    0xfe    0xa6    0x02    0x00    0x76
0x20017448 <cyw43_state+48>:    0x00    0x85    0x00    0x00    0x00    0x00    0x20    0x00
0x20017450 <cyw43_state+56>:    0x00    0x00    0x90    0xde    0x80    0xde    0xf3    0x88
0x20017458 <cyw43_state+64>:    0x2c    0xcf    0x67    0xf2    0x07    0x3e    0x08    0x00
0x20017460 <cyw43_state+72>:    0x45    0x00    0x00    0x5d    0x00    0x00    0x00    0x00
0x20017468 <cyw43_state+80>:    0x40    0x11    0xae    0x29    0x0a    0x2a    0x00    0x6b
0x20017470 <cyw43_state+88>:    0xc0    0xa8    0x01    0x2a    0xf8    0xe3    0x99    0x0d
0x20017478 <cyw43_state+96>:    0x00    0x49    0x6d    0x51    0x17    0xfe    0xfd    0x00
0x20017480 <cyw43_state+104>:   0x01    0x00    0x00    0x00    0x00    0x00    0x13    0x00
0x20017488 <cyw43_state+112>:   0x34    0x00    0x01    0x00    0x00    0x00    0x00    0x00
0x20017490 <cyw43_state+120>:   0x13    0xba    0x17    0x44    0x83    0xb8    0xbc    0x2c
0x20017498 <cyw43_state+128>:   0x8f    0xeb    0x80    0x39    0x1b    0x2d    0x3f    0x43
0x200174a0 <cyw43_state+136>:   0x32    0x4c    0xc9    0x7a    0x83    0x5e    0x8f    0xa6
0x200174a8 <cyw43_state+144>:   0xfd    0x2a    0xb9    0x3b    0x91    0x6f    0x01    0x81
0x200174b0 <cyw43_state+152>:   0x14    0xf8    0xc9    0xb1    0xb0    0x65    0x5b    0xfb
0x200174b8 <cyw43_state+160>:   0x73    0x7a    0xac    0x90    0x9d
```

But then, when calling `cyw43_write_bytes()`, it'll pass the padded length (128) instead of the real buffer size (125), so `cyw43_write_bytes()` will build an SPI command (in this example) to send the whole buffer contents including the padding bytes:

```
0x20017440 <cyw43_state+40>:    0x7d    0x00    0x82    0xff    0x75    0x02    0x00    0x0e
0x20017448 <cyw43_state+48>:    0x00    0x00    0x00    0x00    0x00    0x00    0x20    0x00
0x20017450 <cyw43_state+56>:    0x00    0x00    0x90    0xde    0x80    0xde    0xf3    0x88
0x20017458 <cyw43_state+64>:    0x2c    0xcf    0x67    0xf2    0x07    0x3e    0x08    0x00
0x20017460 <cyw43_state+72>:    0x45    0x00    0x00    0x5d    0x00    0x00    0x00    0x00
0x20017468 <cyw43_state+80>:    0x40    0x11    0xae    0x29    0x0a    0x2a    0x00    0x6b
0x20017470 <cyw43_state+88>:    0xc0    0xa8    0x01    0x2a    0xf8    0xe3    0x99    0x0d
0x20017478 <cyw43_state+96>:    0x00    0x49    0x6d    0x51    0x17    0xfe    0xfd    0x00
0x20017480 <cyw43_state+104>:   0x01    0x00    0x00    0x00    0x00    0x00    0x13    0x00
0x20017488 <cyw43_state+112>:   0x34    0x00    0x01    0x00    0x00    0x00    0x00    0x00
0x20017490 <cyw43_state+120>:   0x13    0xba    0x17    0x44    0x83    0xb8    0xbc    0x2c
0x20017498 <cyw43_state+128>:   0x8f    0xeb    0x80    0x39    0x1b    0x2d    0x3f    0x43
0x200174a0 <cyw43_state+136>:   0x32    0x4c    0xc9    0x7a    0x83    0x5e    0x8f    0xa6
0x200174a8 <cyw43_state+144>:   0xfd    0x2a    0xb9    0x3b    0x91    0x6f    0x01    0x81
0x200174b0 <cyw43_state+152>:   0x14    0xf8    0xc9    0xb1    0xb0    0x65    0x5b    0xfb
0x200174b8 <cyw43_state+160>:   0x73    0x7a    0xac    0x90    0x9d    0x00    0x2c    0xcf
```

Here's the packet capture:

<img width="1373" height="294" alt="capture_cyw43_trailing_bytes" src="https://github.com/user-attachments/assets/9738387e-05be-4004-bfcf-ec5941649936" />
